### PR TITLE
chore: patch react version and children props interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-honeycomb",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-honeycomb",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,23 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-honeycomb",
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
-        "@types/react": "^17.0.2",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
         "react": "*",
         "react-dom": "*",
         "rimraf": "^3.0.2",
         "typescript": "^4.1.5"
       },
       "peerDependencies": {
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       }
     },
     "node_modules/@types/prop-types": {
@@ -29,13 +31,22 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "version": "18.3.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/balanced-match": {
@@ -250,13 +261,22 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "version": "18.3.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
     "react": "*",
     "react-dom": "*",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-honeycomb",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A library for displaying lists as honeycombs with hexagonal cells in React applications",
   "scripts": {
     "prebuild": "rimraf ./lib",

--- a/src/Hexagon.tsx
+++ b/src/Hexagon.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { HoneycombContext } from "./helpers";
 import type { HexagonProps } from "./types";
 
-const Hexagon: React.FC<HexagonProps> = ({
+const Hexagon: React.FC<React.PropsWithChildren<HexagonProps>> = ({
   children,
   className,
   style = {},

--- a/src/HoneycombCell.tsx
+++ b/src/HoneycombCell.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { HoneycombCellProps } from "./types";
 
-const HoneycombCell: React.FC<HoneycombCellProps> = ({
+const HoneycombCell: React.FC<React.PropsWithChildren<HoneycombCellProps>> = ({
   children,
   row,
   column,

--- a/src/ResponsiveHoneycomb.tsx
+++ b/src/ResponsiveHoneycomb.tsx
@@ -6,12 +6,9 @@ import { getGridColumnsCount } from "./helpers";
 
 import type { ResponsiveHoneycombProps } from "./types";
 
-const ResponsiveHoneycomb: React.FC<ResponsiveHoneycombProps> = ({
-  children,
-  size,
-  defaultWidth,
-  ...restProps
-}) => {
+const ResponsiveHoneycomb: React.FC<
+  React.PropsWithChildren<ResponsiveHoneycombProps>
+> = ({ children, size, defaultWidth, ...restProps }) => {
   const containerRef = React.useRef<HTMLUListElement>(null);
   const [columns, setColumns] = React.useState(
     getGridColumnsCount(size, defaultWidth)


### PR DESCRIPTION
This addresses issue https://github.com/taraspolovyi/react-honeycomb/issues/6

The problems happens because react 18 remove children from the component typings, so you now have to explicitly pass it or else use the given `PropsWithChildren` generic as a wrapper for the props